### PR TITLE
Do not hide the connection exception, like "missing driver".

### DIFF
--- a/src/Amp/Database/Datasource.php
+++ b/src/Amp/Database/Datasource.php
@@ -87,16 +87,13 @@ class Datasource {
    * @return bool
    */
   function isValid() {
-    try {
-      $dbh = $this->createPDO();
-      foreach ($dbh->query('SELECT 99 as value') as $row) {
-        if ($row['value'] == 99) {
-          return TRUE;
-        }
+    $dbh = $this->createPDO();
+    foreach ($dbh->query('SELECT 99 as value') as $row) {
+      if ($row['value'] == 99) {
+        return TRUE;
       }
-      $dbh = NULL;
-    } catch (\PDOException $e) {
     }
+    $dbh = NULL;
     return FALSE;
   }
 


### PR DESCRIPTION
I was also getting this error: http://forum.civicrm.org/index.php?topic=35664.0

By removing the try/catch we reveal the true error, a missing driver (php5-mysql).
