### PR TITLE
Fix bug when bad configs given

### DIFF
--- a/src/Amp/Application.php
+++ b/src/Amp/Application.php
@@ -152,7 +152,7 @@ class Application extends \Symfony\Component\Console\Application {
     $commands[] = new \Amp\Command\TestCommand($this, NULL);
     $commands[] = new \Amp\Command\CreateCommand($this, NULL);
     $commands[] = new \Amp\Command\ShowCommand($this, NULL);
-    $commands[] = new \Amp\Command\ExportCommand($this, NULL, $this->getContainer()->get('instances'));
+    $commands[] = new \Amp\Command\ExportCommand($this, NULL);
     $commands[] = new \Amp\Command\SqlCommand($this, NULL, $this->getContainer()->get('instances'));
     $commands[] = new \Amp\Command\DestroyCommand($this, NULL, $this->getContainer()->get('instances'));
     $commands[] = new \Amp\Command\CleanupCommand($this, NULL, $this->getContainer()->get('instances'));

--- a/src/Amp/Application.php
+++ b/src/Amp/Application.php
@@ -151,7 +151,7 @@ class Application extends \Symfony\Component\Console\Application {
     $commands[] = new \Amp\Command\DatadirCommand($this, NULL, $this->getContainer()->get('perm'));
     $commands[] = new \Amp\Command\TestCommand($this, NULL);
     $commands[] = new \Amp\Command\CreateCommand($this, NULL);
-    $commands[] = new \Amp\Command\ShowCommand($this, NULL, $this->getContainer()->get('instances'));
+    $commands[] = new \Amp\Command\ShowCommand($this, NULL);
     $commands[] = new \Amp\Command\ExportCommand($this, NULL, $this->getContainer()->get('instances'));
     $commands[] = new \Amp\Command\SqlCommand($this, NULL, $this->getContainer()->get('instances'));
     $commands[] = new \Amp\Command\DestroyCommand($this, NULL, $this->getContainer()->get('instances'));

--- a/src/Amp/Application.php
+++ b/src/Amp/Application.php
@@ -154,7 +154,7 @@ class Application extends \Symfony\Component\Console\Application {
     $commands[] = new \Amp\Command\ShowCommand($this, NULL);
     $commands[] = new \Amp\Command\ExportCommand($this, NULL);
     $commands[] = new \Amp\Command\SqlCommand($this, NULL);
-    $commands[] = new \Amp\Command\DestroyCommand($this, NULL, $this->getContainer()->get('instances'));
+    $commands[] = new \Amp\Command\DestroyCommand($this, NULL);
     $commands[] = new \Amp\Command\CleanupCommand($this, NULL, $this->getContainer()->get('instances'));
     return $commands;
   }

--- a/src/Amp/Application.php
+++ b/src/Amp/Application.php
@@ -148,7 +148,7 @@ class Application extends \Symfony\Component\Console\Application {
     $commands[] = new \Amp\Command\ConfigSetCommand($this, NULL, $this->getContainer()->get('config.repository'));
     $commands[] = new \Amp\Command\ConfigResetCommand($this, NULL, $this->getContainer()->get('config.repository'));
     $commands[] = new \Amp\Command\ConfigUpgradeCommand($this, NULL, $this->getContainer()->get('config.repository'));
-    $commands[] = new \Amp\Command\DatadirCommand($this, NULL, $this->getContainer()->get('perm'));
+    $commands[] = new \Amp\Command\DatadirCommand($this, NULL);
     $commands[] = new \Amp\Command\TestCommand($this, NULL);
     $commands[] = new \Amp\Command\CreateCommand($this, NULL);
     $commands[] = new \Amp\Command\ShowCommand($this, NULL);

--- a/src/Amp/Application.php
+++ b/src/Amp/Application.php
@@ -150,7 +150,7 @@ class Application extends \Symfony\Component\Console\Application {
     $commands[] = new \Amp\Command\ConfigUpgradeCommand($this, NULL, $this->getContainer()->get('config.repository'));
     $commands[] = new \Amp\Command\DatadirCommand($this, NULL, $this->getContainer()->get('perm'));
     $commands[] = new \Amp\Command\TestCommand($this, NULL);
-    $commands[] = new \Amp\Command\CreateCommand($this, NULL, $this->getContainer()->get('instances'));
+    $commands[] = new \Amp\Command\CreateCommand($this, NULL);
     $commands[] = new \Amp\Command\ShowCommand($this, NULL, $this->getContainer()->get('instances'));
     $commands[] = new \Amp\Command\ExportCommand($this, NULL, $this->getContainer()->get('instances'));
     $commands[] = new \Amp\Command\SqlCommand($this, NULL, $this->getContainer()->get('instances'));

--- a/src/Amp/Application.php
+++ b/src/Amp/Application.php
@@ -149,7 +149,7 @@ class Application extends \Symfony\Component\Console\Application {
     $commands[] = new \Amp\Command\ConfigResetCommand($this, NULL, $this->getContainer()->get('config.repository'));
     $commands[] = new \Amp\Command\ConfigUpgradeCommand($this, NULL, $this->getContainer()->get('config.repository'));
     $commands[] = new \Amp\Command\DatadirCommand($this, NULL, $this->getContainer()->get('perm'));
-    $commands[] = new \Amp\Command\TestCommand($this, NULL, $this->getContainer()->get('instances'));
+    $commands[] = new \Amp\Command\TestCommand($this, NULL);
     $commands[] = new \Amp\Command\CreateCommand($this, NULL, $this->getContainer()->get('instances'));
     $commands[] = new \Amp\Command\ShowCommand($this, NULL, $this->getContainer()->get('instances'));
     $commands[] = new \Amp\Command\ExportCommand($this, NULL, $this->getContainer()->get('instances'));

--- a/src/Amp/Application.php
+++ b/src/Amp/Application.php
@@ -155,7 +155,7 @@ class Application extends \Symfony\Component\Console\Application {
     $commands[] = new \Amp\Command\ExportCommand($this, NULL);
     $commands[] = new \Amp\Command\SqlCommand($this, NULL);
     $commands[] = new \Amp\Command\DestroyCommand($this, NULL);
-    $commands[] = new \Amp\Command\CleanupCommand($this, NULL, $this->getContainer()->get('instances'));
+    $commands[] = new \Amp\Command\CleanupCommand($this, NULL);
     return $commands;
   }
 

--- a/src/Amp/Application.php
+++ b/src/Amp/Application.php
@@ -153,7 +153,7 @@ class Application extends \Symfony\Component\Console\Application {
     $commands[] = new \Amp\Command\CreateCommand($this, NULL);
     $commands[] = new \Amp\Command\ShowCommand($this, NULL);
     $commands[] = new \Amp\Command\ExportCommand($this, NULL);
-    $commands[] = new \Amp\Command\SqlCommand($this, NULL, $this->getContainer()->get('instances'));
+    $commands[] = new \Amp\Command\SqlCommand($this, NULL);
     $commands[] = new \Amp\Command\DestroyCommand($this, NULL, $this->getContainer()->get('instances'));
     $commands[] = new \Amp\Command\CleanupCommand($this, NULL, $this->getContainer()->get('instances'));
     return $commands;

--- a/src/Amp/Command/CleanupCommand.php
+++ b/src/Amp/Command/CleanupCommand.php
@@ -2,7 +2,6 @@
 namespace Amp\Command;
 
 use Amp\Instance;
-use Amp\InstanceRepository;
 use Amp\Util\Filesystem;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -10,11 +9,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class CleanupCommand extends ContainerAwareCommand {
-
-  /**
-   * @var InstanceRepository
-   */
-  private $instances;
 
   /**
    * @var Filesystem
@@ -26,8 +20,7 @@ class CleanupCommand extends ContainerAwareCommand {
    * @param string|null $name
    * @param array $parameters list of configuration parameters to accept ($key => $label)
    */
-  public function __construct(\Amp\Application $app, $name = NULL, InstanceRepository $instances) {
-    $this->instances = $instances;
+  public function __construct(\Amp\Application $app, $name = NULL) {
     $this->fs = new Filesystem();
     parent::__construct($app, $name);
   }
@@ -40,12 +33,13 @@ class CleanupCommand extends ContainerAwareCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    $this->instances->lock();
+    $instances = $this->getContainer()->get('instances');
+    $instances->lock();
     $count = 0;
-    foreach ($this->instances->findAll() as $instance) {
+    foreach ($instances->findAll() as $instance) {
       if ($input->getOption('force') || !file_exists($instance->getRoot())) {
         $output->writeln("Destroy (root={$instance->getRoot()}, name={$instance->getName()}, dsn={$instance->getDsn()})");
-        $this->instances->remove($instance->getId());
+        $instances->remove($instance->getId());
         $count++;
       } else {
         $output->writeln("Skip (root={$instance->getRoot()}, name={$instance->getName()}, dsn={$instance->getDsn()})");
@@ -54,6 +48,6 @@ class CleanupCommand extends ContainerAwareCommand {
 
     $output->writeln("Destroyed {$count} instance(s)");
 
-    $this->instances->save();
+    $instances->save();
   }
 }

--- a/src/Amp/Command/CleanupCommand.php
+++ b/src/Amp/Command/CleanupCommand.php
@@ -18,7 +18,6 @@ class CleanupCommand extends ContainerAwareCommand {
   /**
    * @param \Amp\Application $app
    * @param string|null $name
-   * @param array $parameters list of configuration parameters to accept ($key => $label)
    */
   public function __construct(\Amp\Application $app, $name = NULL) {
     $this->fs = new Filesystem();

--- a/src/Amp/Command/CreateCommand.php
+++ b/src/Amp/Command/CreateCommand.php
@@ -19,7 +19,6 @@ class CreateCommand extends ContainerAwareCommand {
   /**
    * @param \Amp\Application $app
    * @param string|null $name
-   * @param array $parameters list of configuration parameters to accept ($key => $label)
    */
   public function __construct(\Amp\Application $app, $name = NULL) {
     $this->fs = new Filesystem();

--- a/src/Amp/Command/DatadirCommand.php
+++ b/src/Amp/Command/DatadirCommand.php
@@ -2,7 +2,6 @@
 namespace Amp\Command;
 
 use Amp\Instance;
-use Amp\Permission\PermissionInterface;
 use Amp\Util\Filesystem;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -13,18 +12,11 @@ use Symfony\Component\Templating\EngineInterface;
 class DatadirCommand extends ContainerAwareCommand {
 
   /**
-   * @var PermissionInterface
-   */
-  var $perm;
-
-  /**
    * @param \Amp\Application $app
    * @param string|null $name
-   * @param PermissionInterface $perm)
    */
-  public function __construct(\Amp\Application $app, $name = NULL, PermissionInterface $perm) {
+  public function __construct(\Amp\Application $app, $name = NULL) {
     $this->fs = new Filesystem();
-    $this->perm = $perm;
     parent::__construct($app, $name);
   }
 
@@ -36,14 +28,15 @@ class DatadirCommand extends ContainerAwareCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
+    $perm = $this->getContainer()->get('perm');
     foreach ($input->getArgument('path') as $path) {
       if (!$this->fs->exists($path)) {
         $output->writeln("<info>Create data directory: $path</info>");
         $this->fs->mkdir($path);
-        $this->perm->applyDirPermission('write', $path);
+        $perm->applyDirPermission('write', $path);
       } else {
         $output->writeln("<info>Update data directory: $path</info>");
-        $this->perm->applyDirPermission('write', $path);
+        $perm->applyDirPermission('write', $path);
       }
     }
   }

--- a/src/Amp/Command/DestroyCommand.php
+++ b/src/Amp/Command/DestroyCommand.php
@@ -3,7 +3,6 @@ namespace Amp\Command;
 
 use Amp\Database\DatabaseManagementInterface;
 use Amp\Instance;
-use Amp\InstanceRepository;
 use Amp\Util\Filesystem;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -18,17 +17,11 @@ class DestroyCommand extends ContainerAwareCommand {
   private $fs;
 
   /**
-   * @var InstanceRepository
-   */
-  private $instances;
-
-  /**
    * @param \Amp\Application $app
    * @param string|null $name
    * @param array $parameters list of configuration parameters to accept ($key => $label)
    */
-  public function __construct(\Amp\Application $app, $name = NULL, InstanceRepository $instances) {
-    $this->instances = $instances;
+  public function __construct(\Amp\Application $app, $name = NULL) {
     $this->fs = new Filesystem();
     parent::__construct($app, $name);
   }
@@ -52,14 +45,15 @@ class DestroyCommand extends ContainerAwareCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    $this->instances->lock();
-    $instance = $this->instances->find(Instance::makeId($input->getOption('root'), $input->getOption('name')));
+    $instances = $this->getContainer()->get('instances');
+    $instances->lock();
+    $instance = $instances->find(Instance::makeId($input->getOption('root'), $input->getOption('name')));
     if (!$instance) {
       return;
     }
 
-    $this->instances->remove($instance->getId());
-    $this->instances->save();
+    $instances->remove($instance->getId());
+    $instances->save();
   }
 
 }

--- a/src/Amp/Command/DestroyCommand.php
+++ b/src/Amp/Command/DestroyCommand.php
@@ -19,7 +19,6 @@ class DestroyCommand extends ContainerAwareCommand {
   /**
    * @param \Amp\Application $app
    * @param string|null $name
-   * @param array $parameters list of configuration parameters to accept ($key => $label)
    */
   public function __construct(\Amp\Application $app, $name = NULL) {
     $this->fs = new Filesystem();

--- a/src/Amp/Command/ExportCommand.php
+++ b/src/Amp/Command/ExportCommand.php
@@ -2,7 +2,6 @@
 namespace Amp\Command;
 
 use Amp\Instance;
-use Amp\InstanceRepository;
 use Amp\Util\Filesystem;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -13,17 +12,11 @@ use Symfony\Component\Console\Output\StreamOutput;
 class ExportCommand extends ContainerAwareCommand {
 
   /**
-   * @var InstanceRepository
-   */
-  private $instances;
-
-  /**
    * @param \Amp\Application $app
    * @param string|null $name
    * @param array $parameters list of configuration parameters to accept ($key => $label)
    */
-  public function __construct(\Amp\Application $app, $name = NULL, InstanceRepository $instances) {
-    $this->instances = $instances;
+  public function __construct(\Amp\Application $app, $name = NULL) {
     $this->fs = new Filesystem();
     parent::__construct($app, $name);
   }
@@ -52,7 +45,7 @@ class ExportCommand extends ContainerAwareCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    $instance = $this->instances->find(Instance::makeId($input->getOption('root'), $input->getOption('name')));
+    $instance = $this->getContainer()->get('instances')->find(Instance::makeId($input->getOption('root'), $input->getOption('name')));
     if (!$instance) {
       throw new \Exception("Failed to locate instance: " . Instance::makeId($input->getOption('root'), $input->getOption('name')));
     }

--- a/src/Amp/Command/ExportCommand.php
+++ b/src/Amp/Command/ExportCommand.php
@@ -14,7 +14,6 @@ class ExportCommand extends ContainerAwareCommand {
   /**
    * @param \Amp\Application $app
    * @param string|null $name
-   * @param array $parameters list of configuration parameters to accept ($key => $label)
    */
   public function __construct(\Amp\Application $app, $name = NULL) {
     $this->fs = new Filesystem();

--- a/src/Amp/Command/ShowCommand.php
+++ b/src/Amp/Command/ShowCommand.php
@@ -1,7 +1,6 @@
 <?php
 namespace Amp\Command;
 
-use Amp\InstanceRepository;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -10,17 +9,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ShowCommand extends ContainerAwareCommand {
 
   /**
-   * @var InstanceRepository
-   */
-  private $instances;
-
-  /**
    * @param \Amp\Application $app
    * @param string|null $name
    * @param array $parameters list of configuration parameters to accept ($key => $label)
    */
-  public function __construct(\Amp\Application $app, $name = NULL, InstanceRepository $instances) {
-    $this->instances = $instances;
+  public function __construct(\Amp\Application $app, $name = NULL) {
     parent::__construct($app, $name);
   }
 
@@ -31,9 +24,10 @@ class ShowCommand extends ContainerAwareCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
+    $instances = $this->getContainer()->get('instances');
     if ($output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL) {
       $rows = array();
-      foreach ($this->instances->findAll() as $instance) {
+      foreach ($instances->findAll() as $instance) {
         $rows[] = array('root', $instance->getRoot());
         $rows[] = array('name', $instance->getName());
         $rows[] = array('dsn', $instance->getDsn());
@@ -49,7 +43,7 @@ class ShowCommand extends ContainerAwareCommand {
     }
     else {
       $rows = array();
-      foreach ($this->instances->findAll() as $instance) {
+      foreach ($instances->findAll() as $instance) {
         $rows[] = array(
           $instance->getRoot(),
           $instance->getName(),

--- a/src/Amp/Command/ShowCommand.php
+++ b/src/Amp/Command/ShowCommand.php
@@ -11,7 +11,6 @@ class ShowCommand extends ContainerAwareCommand {
   /**
    * @param \Amp\Application $app
    * @param string|null $name
-   * @param array $parameters list of configuration parameters to accept ($key => $label)
    */
   public function __construct(\Amp\Application $app, $name = NULL) {
     parent::__construct($app, $name);

--- a/src/Amp/Command/SqlCommand.php
+++ b/src/Amp/Command/SqlCommand.php
@@ -2,7 +2,6 @@
 namespace Amp\Command;
 
 use Amp\Instance;
-use Amp\InstanceRepository;
 use Amp\Util\Filesystem;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -13,17 +12,11 @@ use Symfony\Component\Console\Output\StreamOutput;
 class SqlCommand extends ContainerAwareCommand {
 
   /**
-   * @var InstanceRepository
-   */
-  private $instances;
-
-  /**
    * @param \Amp\Application $app
    * @param string|null $name
    * @param array $parameters list of configuration parameters to accept ($key => $label)
    */
-  public function __construct(\Amp\Application $app, $name = NULL, InstanceRepository $instances) {
-    $this->instances = $instances;
+  public function __construct(\Amp\Application $app, $name = NULL) {
     $this->fs = new Filesystem();
     parent::__construct($app, $name);
   }
@@ -47,7 +40,7 @@ class SqlCommand extends ContainerAwareCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    $instance = $this->instances->find(Instance::makeId($input->getOption('root'), $input->getOption('name')));
+    $instance = $this->getContainer()->get('instances')->find(Instance::makeId($input->getOption('root'), $input->getOption('name')));
     if (!$instance) {
       throw new \Exception("Failed to locate instance: " . Instance::makeId($input->getOption('root'), $input->getOption('name')));
     }

--- a/src/Amp/Command/SqlCommand.php
+++ b/src/Amp/Command/SqlCommand.php
@@ -14,7 +14,6 @@ class SqlCommand extends ContainerAwareCommand {
   /**
    * @param \Amp\Application $app
    * @param string|null $name
-   * @param array $parameters list of configuration parameters to accept ($key => $label)
    */
   public function __construct(\Amp\Application $app, $name = NULL) {
     $this->fs = new Filesystem();

--- a/src/Amp/Command/TestCommand.php
+++ b/src/Amp/Command/TestCommand.php
@@ -25,7 +25,6 @@ class TestCommand extends ContainerAwareCommand {
   /**
    * @param \Amp\Application $app
    * @param string|null $name
-   * @param array $parameters list of configuration parameters to accept ($key => $label)
    */
   public function __construct(\Amp\Application $app, $name = NULL) {
     $this->fs = new Filesystem();


### PR DESCRIPTION
@totten I'm not sure how you like your commits in general. I prefer them to be as atomic as possible (so reverts are easy)
Hence, I've split this conversion into multiple commits.
If you want, I could squash them into 1 commit

Note: I've also changes the `$instances` variable to be a local variable as being a class variable was not needed anymore.

EDIT:
Also, I notice no CI services are enabled for PRs. I've run the `phpunit` locally and it worked fine:
```
Configuration read from /home/ajk/Documents/civi/amp/phpunit.xml.dist
..........
Time: 3.04 seconds, Memory: 3.50Mb
OK (10 tests, 10 assertions)
```