### PR TITLE
TestCommand - Canary should not require amp's autoloader

### DIFF
--- a/src/Amp/views/canary.php
+++ b/src/Amp/views/canary.php
@@ -15,11 +15,12 @@ if (isset($_SERVER['HTTP_CLIENT_IP'])
 }
 
 $config = require 'config.php';
+$errors = array();
 
 // ---------- Test HTTP inputs ----------
 
-if ($_REQUEST['exampleData'] !== 'foozball') {
-  echo "Error: Expected GET or POST value 'exampleData=foozball'";
+if (!isset($_REQUEST['exampleData']) || $_REQUEST['exampleData'] !== 'foozball') {
+  $errors[]= "Error: Expected GET or POST value 'exampleData=foozball'";
 }
 
 // ---------- Test database ----------
@@ -31,28 +32,30 @@ try {
     if ($row['value'] == 99) {
       // ok
     } else {
-      echo "Error: Bad query result <br/>";
-      die();
+      $errors[] = "Error: Bad query result <br/>";
     }
   }
   $dbh = NULL;
 } catch (PDOException $e) {
-  echo "Error: " . $e->getMessage() . "<br/>";
-  die();
+  $errors[] = "Error: " . $e->getMessage() . "<br/>";
 }
 
 // ---------- Test file permissions ----------
 
 $dataFile = $config['dataDir'] . '/example.txt';
 if (FALSE === file_put_contents($dataFile, "data")) {
-  echo "Error: Failed to write $dataFile";
-  die();
+  $errors[] = "Error: Failed to write $dataFile";
 }
 if (FALSE === unlink($dataFile)) {
-  echo "Error: Failed to remove $dataFile";
-  die();
+  $errors[] = "Error: Failed to remove $dataFile";
 }
 
-// ---------- OK ----------
+// ---------- Wrap up ----------
 
-echo "<?= $expectedResponse ?>";
+if (empty($errors)) {
+  echo "<?= $expectedResponse ?>";
+}
+else {
+  echo implode("\n", $errors);
+  die();
+}

--- a/src/Amp/views/canary.php
+++ b/src/Amp/views/canary.php
@@ -14,15 +14,19 @@ if (isset($_SERVER['HTTP_CLIENT_IP'])
   exit('Connection must originate on localhost');
 }
 
+$config = require 'config.php';
+
+// ---------- Test HTTP inputs ----------
+
+if ($_REQUEST['exampleData'] !== 'foozball') {
+  echo "Error: Expected GET or POST value 'exampleData=foozball'";
+}
+
 // ---------- Test database ----------
 
-require_once "<?php echo addslashes($autoloader) ?>";
-$datasource = new \Amp\Database\Datasource(array(
-  'civi_dsn' => $_POST['dsn']
-));
-
 try {
-  $dbh = $datasource->createPDO();
+  $dbh = new \PDO($config['dsn'], $config['user'], $config['pass']);
+  $dbh->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
   foreach ($dbh->query('SELECT 99 as value') as $row) {
     if ($row['value'] == 99) {
       // ok
@@ -39,7 +43,7 @@ try {
 
 // ---------- Test file permissions ----------
 
-$dataFile = '<?php echo addslashes($dataDir) ?>/example.txt';
+$dataFile = $config['dataDir'] . '/example.txt';
 if (FALSE === file_put_contents($dataFile, "data")) {
   echo "Error: Failed to write $dataFile";
   die();


### PR DESCRIPTION
Fetching the autoloader fails with PHAR-based installations, and the only
thing canary uses it for is to parse a DSN.  And, unfortunately, loading a
class from an *executable* PHAR produces weird output (e.g. `#!/usr/bin/env
php`).

Instead, prepare the DSN in a more usable format and put it into a config
file.  This has side benefit of being a more realistic representation of
how most PHP apps work (i.e.  create source code, then run amp, then create
config file).